### PR TITLE
fix square root of null value

### DIFF
--- a/calculator.js
+++ b/calculator.js
@@ -39,7 +39,7 @@ function calculateSquareRoot(value=null) {
         let display = document.getElementById('display');
         v = display.value;
     } else {
-        v = value;
+        v = 0;
     }
     return Math.sqrt(v);
 }


### PR DESCRIPTION
Fix the bug involved in taking the square root of a number. Give a default value if the number inputted is null.